### PR TITLE
Revamp Explore page: add title, reposition search bar, load all events

### DIFF
--- a/code/app/src/main/java/com/example/eventsapp/ExploreFragment.java
+++ b/code/app/src/main/java/com/example/eventsapp/ExploreFragment.java
@@ -1,10 +1,132 @@
 package com.example.eventsapp;
 
+import android.os.Bundle;
+import android.util.Log;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.ImageView;
+import android.widget.TextView;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 import androidx.fragment.app.Fragment;
+import androidx.recyclerview.widget.LinearLayoutManager;
+import androidx.recyclerview.widget.RecyclerView;
+
+import com.google.android.material.card.MaterialCardView;
+import com.google.firebase.firestore.CollectionReference;
+import com.google.firebase.firestore.FirebaseFirestore;
+import com.google.firebase.firestore.QueryDocumentSnapshot;
+
+import java.util.ArrayList;
+import java.util.List;
 
 public class ExploreFragment extends Fragment {
+    private static final String TAG = "ExploreFragment";
+    private final List<Event> eventList = new ArrayList<>();
+    private ExploreEventAdapter adapter;
+    private RecyclerView rvEvents;
+
     public ExploreFragment() { super(R.layout.fragment_explore); }
 
-    //add ability to view events that are joinable
+    @Override
+    public void onViewCreated(@NonNull View view, @Nullable Bundle savedInstanceState) {
+        super.onViewCreated(view, savedInstanceState);
 
+        rvEvents = view.findViewById(R.id.rvEvents);
+
+        adapter = new ExploreEventAdapter(eventList, event -> {
+            EventDialogFragment.newInstance(event)
+                    .show(requireActivity().getSupportFragmentManager(), "Event Details");
+        });
+        rvEvents.setLayoutManager(new LinearLayoutManager(requireContext()));
+        rvEvents.setAdapter(adapter);
+
+        loadAllEvents();
+    }
+
+    private void loadAllEvents() {
+        CollectionReference eventsRef = FirebaseFirestore.getInstance().collection("events");
+        eventsRef.addSnapshotListener((value, error) -> {
+            if (error != null) {
+                Log.e(TAG, "Error loading events", error);
+                return;
+            }
+            if (value != null && isAdded()) {
+                eventList.clear();
+                for (QueryDocumentSnapshot snapshot : value) {
+                    String id = snapshot.getString("id");
+                    String name = snapshot.getString("name");
+                    Long amountLong = snapshot.getLong("amount");
+                    int amount = (amountLong != null) ? amountLong.intValue() : 0;
+                    String description = snapshot.getString("description");
+                    String posterUrl = snapshot.getString("posterUrl");
+                    Long sampleLong = snapshot.getLong("sampleSize");
+                    int sampleSize = (sampleLong != null) ? sampleLong.intValue() : 0;
+                    if (id == null) id = snapshot.getId();
+                    if (name == null) name = "";
+                    if (description == null) description = "";
+                    if (posterUrl == null) posterUrl = "";
+
+                    if (amount != 0) {
+                        eventList.add(new Event(id, name, amount, description, posterUrl, sampleSize));
+                    }
+                }
+                adapter.notifyDataSetChanged();
+            }
+        });
+    }
+
+    private static class ExploreEventAdapter extends RecyclerView.Adapter<ExploreEventAdapter.ViewHolder> {
+        private final List<Event> events;
+        private final OnEventClickListener listener;
+
+        interface OnEventClickListener {
+            void onEventClick(Event event);
+        }
+
+        ExploreEventAdapter(List<Event> events, OnEventClickListener listener) {
+            this.events = events;
+            this.listener = listener;
+        }
+
+        @NonNull
+        @Override
+        public ViewHolder onCreateViewHolder(@NonNull ViewGroup parent, int viewType) {
+            View view = android.view.LayoutInflater.from(parent.getContext())
+                    .inflate(R.layout.item_event_card, parent, false);
+            return new ViewHolder(view);
+        }
+
+        @Override
+        public void onBindViewHolder(@NonNull ViewHolder holder, int position) {
+            Event event = events.get(position);
+            holder.tvEventName.setText(event.getName());
+            holder.tvEventHost.setText(event.getDescription());
+            holder.tvAvatarLetter.setText(
+                    event.getName().isEmpty() ? "?" : String.valueOf(event.getName().charAt(0)).toUpperCase()
+            );
+            holder.itemView.setOnClickListener(v -> listener.onEventClick(event));
+        }
+
+        @Override
+        public int getItemCount() {
+            return events.size();
+        }
+
+        static class ViewHolder extends RecyclerView.ViewHolder {
+            TextView tvEventName, tvEventHost, tvAvatarLetter, tvEventDate, tvEventTime;
+            ImageView ivThumb;
+
+            ViewHolder(@NonNull View itemView) {
+                super(itemView);
+                tvEventName = itemView.findViewById(R.id.tvEventName);
+                tvEventHost = itemView.findViewById(R.id.tvEventHost);
+                tvAvatarLetter = itemView.findViewById(R.id.tvAvatarLetter);
+                tvEventDate = itemView.findViewById(R.id.tvEventDate);
+                tvEventTime = itemView.findViewById(R.id.tvEventTime);
+                ivThumb = itemView.findViewById(R.id.ivThumb);
+            }
+        }
+    }
 }

--- a/code/app/src/main/res/layout/fragment_explore.xml
+++ b/code/app/src/main/res/layout/fragment_explore.xml
@@ -15,18 +15,19 @@
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintEnd_toEndOf="parent">
 
-        <ImageButton
-            android:id="@+id/btnTopIconNormal"
-            android:layout_width="44dp"
-            android:layout_height="44dp"
-            android:layout_marginTop="16dp"
-            android:layout_marginEnd="16dp"
-            android:background="?attr/selectableItemBackgroundBorderless"
-            android:contentDescription="Top icon"
-            android:padding="10dp"
-            android:scaleType="centerInside"
-            app:srcCompat="@android:drawable/checkbox_off_background"
+        <TextView
+            android:id="@+id/tvExploreTitle"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:text="Explore"
+            android:textColor="@color/colorTextPrimary"
+            android:textSize="28sp"
+            android:textStyle="bold"
+            android:layout_marginStart="20dp"
+            android:layout_marginEnd="20dp"
+            android:layout_marginTop="24dp"
             app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintEnd_toEndOf="parent" />
 
         <com.google.android.material.card.MaterialCardView
@@ -40,7 +41,7 @@
             app:cardElevation="0dp"
             app:cardBackgroundColor="@color/colorSearchBar"
             app:strokeWidth="0dp"
-            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/tvExploreTitle"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintEnd_toStartOf="@id/btnTopIconNormal">
 
@@ -88,19 +89,18 @@
             </androidx.constraintlayout.widget.ConstraintLayout>
         </com.google.android.material.card.MaterialCardView>
 
-        <TextView
-            android:id="@+id/tvFeatured"
-            android:layout_width="0dp"
-            android:layout_height="wrap_content"
-            android:text="Featured"
-            android:textColor="@color/colorTextPrimary"
-            android:textSize="20sp"
-            android:textStyle="bold"
-            android:layout_marginStart="20dp"
-            android:layout_marginEnd="20dp"
-            android:layout_marginTop="24dp"
-            app:layout_constraintTop_toBottomOf="@id/cardSearchNormal"
-            app:layout_constraintStart_toStartOf="parent"
+        <ImageButton
+            android:id="@+id/btnTopIconNormal"
+            android:layout_width="44dp"
+            android:layout_height="44dp"
+            android:layout_marginEnd="16dp"
+            android:background="?attr/selectableItemBackgroundBorderless"
+            android:contentDescription="Top icon"
+            android:padding="10dp"
+            android:scaleType="centerInside"
+            app:srcCompat="@android:drawable/checkbox_off_background"
+            app:layout_constraintTop_toTopOf="@id/cardSearchNormal"
+            app:layout_constraintBottom_toBottomOf="@id/cardSearchNormal"
             app:layout_constraintEnd_toEndOf="parent" />
 
         <androidx.recyclerview.widget.RecyclerView
@@ -109,9 +109,9 @@
             android:layout_height="0dp"
             android:paddingStart="20dp"
             android:paddingEnd="20dp"
-            android:paddingTop="12dp"
+            android:paddingTop="16dp"
             android:clipToPadding="false"
-            app:layout_constraintTop_toBottomOf="@id/tvFeatured"
+            app:layout_constraintTop_toBottomOf="@id/cardSearchNormal"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintEnd_toEndOf="parent" />


### PR DESCRIPTION
- Add bold "Explore" title at the top of the page
- Move search bar and inbox button below the title
- Remove "Featured" text section
- Load and display all events from Firestore using event card layout
- Tap event cards to view details via EventDialogFragment